### PR TITLE
Support basic ontology resolution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,7 @@ jobs:
         pytest tests/test_ogr_shapefile_provider.py
         pytest tests/test_ogr_sqlite_provider.py
         pytest tests/test_ogr_wfs_provider.py
+        pytest tests/test_ontology.py
         pytest tests/test_postgresql_manager.py
         # pytest tests/test_ogr_wfs_provider_live.py  # NOTE: these are skipped in the file but listed here for completeness
         pytest tests/test_openapi.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md LICENSE.md requirements.txt
-recursive-include pygeoapi *.html *.json *.jsonld *.yml
+recursive-include pygeoapi *.html *.json *.jsonld *.yml *.ttl
 recursive-include pygeoapi/static *

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1285,7 +1285,7 @@ def describe_collections(api: API, request: APIRequest,
                             continue
 
                         value['title'] = collection_mapping[key]['title']
-                        key = collection_mapping[key]['id']
+                        key = collection_mapping[key]['key']
                         LOGGER.info(f'Using ODM2 Variable: {key}')
 
                     collection['parameter_names'][key] = {

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -961,12 +961,12 @@ def describe_collections(api: API, request: APIRequest,
         collections_dict = collections
 
     LOGGER.debug('Processing parameter-name parameter')
-    ext_qargs = ''
     parameternames = request.params.get('parameter-name') or []
+    ext_qargs = (f'?parameter-name={parameternames}'
+                 if isinstance(parameternames, str) else '')
     if isinstance(parameternames, str):
-        parameternames_ = parameternames.split(',')
-        onto_mapping = get_mapping(parameternames_)
-        ext_qargs = f'parameter-name={parameternames}'
+        parameternames = parameternames.split(',')
+        onto_mapping = get_mapping(parameternames)
 
     LOGGER.debug('Creating collections')
     for k, v in collections_dict.items():
@@ -1279,7 +1279,7 @@ def describe_collections(api: API, request: APIRequest,
             if parameters:
                 collection['parameter_names'] = {}
                 for key, value in parameters.items():
-                    if parameternames != [] and k in onto_mapping:
+                    if ext_qargs and k in onto_mapping:
                         collection_mapping = onto_mapping[k]
                         if key not in collection_mapping:
                             continue

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -763,17 +763,17 @@ def landing_page(api: API,
         'rel': request.get_linkrel(F_JSON),
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('This document as JSON', request.locale),
-        'href': f"{api.base_url}?f={F_JSON}{ext_qargs}"
+        'href': f"{api.base_url}?f={F_JSON}&{ext_qargs}"
     }, {
         'rel': request.get_linkrel(F_JSONLD),
         'type': FORMAT_TYPES[F_JSONLD],
         'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-        'href': f"{api.base_url}?f={F_JSONLD}{ext_qargs}"
+        'href': f"{api.base_url}?f={F_JSONLD}&{ext_qargs}"
     }, {
         'rel': request.get_linkrel(F_HTML),
         'type': FORMAT_TYPES[F_HTML],
         'title': l10n.translate('This document as HTML', request.locale),
-        'href': f"{api.base_url}?f={F_HTML}{ext_qargs}",
+        'href': f"{api.base_url}?f={F_HTML}&{ext_qargs}",
         'hreflang': api.default_locale
     }, {
         'rel': 'service-desc',
@@ -795,7 +795,7 @@ def landing_page(api: API,
         'rel': 'data',
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('Collections', request.locale),
-        'href': f'{api.get_collections_url()}{ext_qargs}'
+        'href': f'{api.get_collections_url()}&{ext_qargs}'
     }, {
         'rel': 'http://www.opengis.net/def/rel/ogc/1.0/processes',
         'type': FORMAT_TYPES[F_JSON],

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -746,6 +746,10 @@ def landing_page(api: API,
                 request.locale)
     }
 
+    parameternames = request.params.get('parameter-name')
+    ext_qargs = (f'?parameter-name={parameternames}'
+                 if isinstance(parameternames, str) else '')
+
     LOGGER.debug('Creating links')
     # TODO: put title text in config or translatable files?
     fcm['links'] = [{
@@ -759,17 +763,17 @@ def landing_page(api: API,
         'rel': request.get_linkrel(F_JSON),
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('This document as JSON', request.locale),
-        'href': f"{api.base_url}?f={F_JSON}"
+        'href': f"{api.base_url}?f={F_JSON}{ext_qargs}"
     }, {
         'rel': request.get_linkrel(F_JSONLD),
         'type': FORMAT_TYPES[F_JSONLD],
         'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-        'href': f"{api.base_url}?f={F_JSONLD}"
+        'href': f"{api.base_url}?f={F_JSONLD}{ext_qargs}"
     }, {
         'rel': request.get_linkrel(F_HTML),
         'type': FORMAT_TYPES[F_HTML],
         'title': l10n.translate('This document as HTML', request.locale),
-        'href': f"{api.base_url}?f={F_HTML}",
+        'href': f"{api.base_url}?f={F_HTML}{ext_qargs}",
         'hreflang': api.default_locale
     }, {
         'rel': 'service-desc',
@@ -791,7 +795,7 @@ def landing_page(api: API,
         'rel': 'data',
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('Collections', request.locale),
-        'href': api.get_collections_url()
+        'href': f'{api.get_collections_url()}{ext_qargs}'
     }, {
         'rel': 'http://www.opengis.net/def/rel/ogc/1.0/processes',
         'type': FORMAT_TYPES[F_JSON],
@@ -957,10 +961,12 @@ def describe_collections(api: API, request: APIRequest,
         collections_dict = collections
 
     LOGGER.debug('Processing parameter-name parameter')
+    ext_qargs = ''
     parameternames = request.params.get('parameter-name') or []
     if isinstance(parameternames, str):
         parameternames_ = parameternames.split(',')
         onto_mapping = get_mapping(parameternames_)
+        ext_qargs = f'parameter-name={parameternames}'
 
     LOGGER.debug('Creating collections')
     for k, v in collections_dict.items():
@@ -1055,31 +1061,31 @@ def describe_collections(api: API, request: APIRequest,
             'type': FORMAT_TYPES[F_JSON],
             'rel': 'root',
             'title': l10n.translate('The landing page of this server as JSON', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_JSON}"
+            'href': f"{api.base_url}?f={F_JSON}&{ext_qargs}"
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': 'root',
             'title': l10n.translate('The landing page of this server as HTML', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_HTML}"
+            'href': f"{api.base_url}?f={F_HTML}&{ext_qargs}"
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_JSON],
             'rel': request.get_linkrel(F_JSON),
             'title': l10n.translate('This document as JSON', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSON}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_JSON}{ext_qargs}'
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_JSONLD],
             'rel': request.get_linkrel(F_JSONLD),
             'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSONLD}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_JSONLD}&{ext_qargs}'
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': request.get_linkrel(F_HTML),
             'title': l10n.translate('This document as HTML', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_HTML}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_HTML}&{ext_qargs}'
         })
 
         if collection_data_type == 'record':
@@ -1306,7 +1312,7 @@ def describe_collections(api: API, request: APIRequest,
             for qt in p.get_query_types():
                 data_query = {
                     'link': {
-                        'href': f'{api.get_collections_url()}/{k}/{qt}',
+                        'href': f'{api.get_collections_url()}/{k}/{qt}?{ext_qargs}',  # noqa
                         'rel': 'data',
                         'variables': {
                             'query_type': qt
@@ -1324,13 +1330,13 @@ def describe_collections(api: API, request: APIRequest,
                     'type': 'application/json',
                     'rel': 'data',
                     'title': title1,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_JSON}'
+                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_JSON}&{ext_qargs}'  # noqa
                 })
                 collection['links'].append({
                     'type': FORMAT_TYPES[F_HTML],
                     'rel': 'data',
                     'title': title2,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_HTML}'
+                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_HTML}&{ext_qargs}'  # noqa
                 })
 
         if dataset is not None and k == dataset:
@@ -1345,19 +1351,19 @@ def describe_collections(api: API, request: APIRequest,
             'type': FORMAT_TYPES[F_JSON],
             'rel': request.get_linkrel(F_JSON),
             'title': l10n.translate('This document as JSON', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_JSON}'
+            'href': f'{api.get_collections_url()}?f={F_JSON}{ext_qargs}'
         })
         fcm['links'].append({
             'type': FORMAT_TYPES[F_JSONLD],
             'rel': request.get_linkrel(F_JSONLD),
             'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_JSONLD}'
+            'href': f'{api.get_collections_url()}?f={F_JSONLD}{ext_qargs}'
         })
         fcm['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': request.get_linkrel(F_HTML),
             'title': l10n.translate('This document as HTML', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_HTML}'
+            'href': f'{api.get_collections_url()}?f={F_HTML}{ext_qargs}'
         })
 
     if request.format == F_HTML:  # render

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1284,8 +1284,8 @@ def describe_collections(api: API, request: APIRequest,
                         if key not in collection_mapping:
                             continue
 
-                        value['title'] = collection_mapping[key]['name']
-                        key = collection_mapping[key]['id']
+                        value['title'] = collection_mapping[key]['title']
+                        key = collection_mapping[key]['key']
                         LOGGER.info(f'Using ODM2 Variable: {key}')
 
                     collection['parameter_names'][key] = {
@@ -1325,7 +1325,6 @@ def describe_collections(api: API, request: APIRequest,
                 title1 = f'{qt} {title1}'
                 title2 = l10n.translate('query for this collection as HTML', request.locale)  # noqa
                 title2 = f'{qt} {title2}'
-
                 collection['links'].append({
                     'type': 'application/json',
                     'rel': 'data',

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -763,17 +763,17 @@ def landing_page(api: API,
         'rel': request.get_linkrel(F_JSON),
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('This document as JSON', request.locale),
-        'href': f"{api.base_url}?f={F_JSON}&{ext_qargs}"
+        'href': f"{api.base_url}?f={F_JSON}"
     }, {
         'rel': request.get_linkrel(F_JSONLD),
         'type': FORMAT_TYPES[F_JSONLD],
         'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-        'href': f"{api.base_url}?f={F_JSONLD}&{ext_qargs}"
+        'href': f"{api.base_url}?f={F_JSONLD}"
     }, {
         'rel': request.get_linkrel(F_HTML),
         'type': FORMAT_TYPES[F_HTML],
         'title': l10n.translate('This document as HTML', request.locale),
-        'href': f"{api.base_url}?f={F_HTML}&{ext_qargs}",
+        'href': f"{api.base_url}?f={F_HTML}",
         'hreflang': api.default_locale
     }, {
         'rel': 'service-desc',
@@ -795,7 +795,7 @@ def landing_page(api: API,
         'rel': 'data',
         'type': FORMAT_TYPES[F_JSON],
         'title': l10n.translate('Collections', request.locale),
-        'href': f'{api.get_collections_url()}&{ext_qargs}'
+        'href': api.get_collections_url() + ext_qargs
     }, {
         'rel': 'http://www.opengis.net/def/rel/ogc/1.0/processes',
         'type': FORMAT_TYPES[F_JSON],
@@ -1061,31 +1061,31 @@ def describe_collections(api: API, request: APIRequest,
             'type': FORMAT_TYPES[F_JSON],
             'rel': 'root',
             'title': l10n.translate('The landing page of this server as JSON', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_JSON}&{ext_qargs}"
+            'href': f"{api.base_url}?f={F_JSON}"
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': 'root',
             'title': l10n.translate('The landing page of this server as HTML', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_HTML}&{ext_qargs}"
+            'href': f"{api.base_url}?f={F_HTML}"
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_JSON],
             'rel': request.get_linkrel(F_JSON),
             'title': l10n.translate('This document as JSON', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSON}{ext_qargs}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_JSON}'
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_JSONLD],
             'rel': request.get_linkrel(F_JSONLD),
             'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSONLD}&{ext_qargs}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_JSONLD}'
         })
         collection['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': request.get_linkrel(F_HTML),
             'title': l10n.translate('This document as HTML', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_HTML}&{ext_qargs}'
+            'href': f'{api.get_collections_url()}/{k}?f={F_HTML}'
         })
 
         if collection_data_type == 'record':
@@ -1285,7 +1285,7 @@ def describe_collections(api: API, request: APIRequest,
                             continue
 
                         value['title'] = collection_mapping[key]['title']
-                        key = collection_mapping[key]['key']
+                        key = collection_mapping[key]['id']
                         LOGGER.info(f'Using ODM2 Variable: {key}')
 
                     collection['parameter_names'][key] = {
@@ -1312,7 +1312,7 @@ def describe_collections(api: API, request: APIRequest,
             for qt in p.get_query_types():
                 data_query = {
                     'link': {
-                        'href': f'{api.get_collections_url()}/{k}/{qt}?{ext_qargs}',  # noqa
+                        'href': f'{api.get_collections_url()}/{k}/{qt}',
                         'rel': 'data',
                         'variables': {
                             'query_type': qt
@@ -1325,17 +1325,18 @@ def describe_collections(api: API, request: APIRequest,
                 title1 = f'{qt} {title1}'
                 title2 = l10n.translate('query for this collection as HTML', request.locale)  # noqa
                 title2 = f'{qt} {title2}'
+
                 collection['links'].append({
                     'type': 'application/json',
                     'rel': 'data',
                     'title': title1,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_JSON}&{ext_qargs}'  # noqa
+                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_JSON}'
                 })
                 collection['links'].append({
                     'type': FORMAT_TYPES[F_HTML],
                     'rel': 'data',
                     'title': title2,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_HTML}&{ext_qargs}'  # noqa
+                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_HTML}'
                 })
 
         if dataset is not None and k == dataset:
@@ -1350,19 +1351,19 @@ def describe_collections(api: API, request: APIRequest,
             'type': FORMAT_TYPES[F_JSON],
             'rel': request.get_linkrel(F_JSON),
             'title': l10n.translate('This document as JSON', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_JSON}{ext_qargs}'
+            'href': f'{api.get_collections_url()}?f={F_JSON}'
         })
         fcm['links'].append({
             'type': FORMAT_TYPES[F_JSONLD],
             'rel': request.get_linkrel(F_JSONLD),
             'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_JSONLD}{ext_qargs}'
+            'href': f'{api.get_collections_url()}?f={F_JSONLD}'
         })
         fcm['links'].append({
             'type': FORMAT_TYPES[F_HTML],
             'rel': request.get_linkrel(F_HTML),
             'title': l10n.translate('This document as HTML', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}?f={F_HTML}{ext_qargs}'
+            'href': f'{api.get_collections_url()}?f={F_HTML}'
         })
 
     if request.format == F_HTML:  # render

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -48,6 +48,7 @@ from shapely.wkt import loads as shapely_loads
 
 from pygeoapi import l10n
 from pygeoapi.api import evaluate_limit
+from pygeoapi.ontology import get_mapping
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderItemNotFoundError)
@@ -297,6 +298,10 @@ def get_collection_edr_query(api: API, request: APIRequest,
     parameternames = request.params.get('parameter-name') or []
     if isinstance(parameternames, str):
         parameternames = parameternames.split(',')
+
+        onto_mapping = get_mapping(parameternames)
+        if dataset in onto_mapping:
+            parameternames = list(onto_mapping[dataset].keys())
 
     bbox = None
     if query_type in ['cube', 'locations']:

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -385,6 +385,9 @@ def get_collection_edr_query(api: API, request: APIRequest,
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
 
+    # TODO: Inject ODM2 Parameter in CovJSON 
+    # if data['type'] in ('Coverage', 'CoverageCollection', 'Domain'):
+
     if request.format == F_HTML:  # render
         tpl_config = api.get_dataset_templates(dataset)
 

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -385,7 +385,7 @@ def get_collection_edr_query(api: API, request: APIRequest,
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
 
-    # TODO: Inject ODM2 Parameter in CovJSON 
+    # TODO: Inject ODM2 Parameter in CovJSON
     # if data['type'] in ('Coverage', 'CoverageCollection', 'Domain'):
 
     if request.format == F_HTML:  # render

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -1,3 +1,31 @@
+# =================================================================
+#
+# Authors: Ben Webb <bwebb@lincolninst.edu>
+#
+# Copyright (c) 2025 Ben Webb
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
 
 import functools
 import logging

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -32,6 +32,7 @@ import logging
 import os
 from pathlib import Path
 from rdflib import Graph
+from typing import TypedDict
 
 
 LOGGER = logging.getLogger(__name__)
@@ -48,10 +49,17 @@ PREFIX variablename: <http://vocabulary.odm2.org/variablename/>
 PREFIX dct: <http://purl.org/dc/terms/>
 '''
 
+# ?collection_id is the name of the configured resource
+# ?parameter_name is the parameter name of the source system
 BINDS = '''
 BIND(CONCAT(LCASE(STR(?label)), "-edr") AS ?collection_id)
 BIND(REPLACE(STR(?parameter), "^.*[#/]", "") AS ?parameter_name)
 '''
+
+
+class KeyTitleDict(TypedDict):
+    key: str
+    title: str
 
 
 @functools.cache
@@ -61,7 +69,17 @@ def get_graph() -> Graph:
     return Graph().parse(GRAPH)
 
 
-def get_mapping(parameter_names: list) -> dict:
+def get_mapping(parameter_names: list
+                ) -> dict[str, dict[str, KeyTitleDict]]:
+    """
+    Query Ontology graph for matching EDR collectionad and parameters
+    to create a dictionary mapping from OGC Collection to ODM2
+    Vocabulary
+
+    :param parameter_names: `list` of ODM2 parameter shortnames or IRIs
+
+    :returns: `dict` of ontology mapping
+    """
     resp = {}
     VALUES = ''
     if parameter_names != ['*']:

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -28,10 +28,7 @@ BIND(REPLACE(STR(?parameter), "^.*/", "") AS ?parameter_name)
 
 @functools.cache
 def get_graph() -> Graph:
-
-    g = Graph()
-    g.parse(GRAPH)
-    return g
+    return Graph().parse(GRAPH)
 
 
 def get_mapping(parameter_names: list) -> dict:
@@ -59,22 +56,18 @@ def get_mapping(parameter_names: list) -> dict:
             {BINDS}
         }}
     '''
-    qres = get_graph().query(query)
-    for row in qres:
-        cid = str(row.collection_id)
-        pname = str(row.parameter_name)
+
+    for c in get_graph().query(query):
+        cid = str(c.collection_id)
+        pname = str(c.parameter_name)
         if cid not in resp:
             resp[cid] = {
                 pname: {
-                    'id': str(row.odmvariable),
-                    'name': str(row.odmvarname)
+                    'key': str(c.odmvariable),
+                    'title': str(c.odmvarname)
                 }
             }
 
     return resp
 
-
-if __name__ == '__main__':
-    get_mapping(['reservoirStorage'])
-else:
-    get_graph()
+get_graph()

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -63,18 +63,18 @@ def get_graph() -> Graph:
 
 def get_mapping(parameter_names: list) -> dict:
     resp = {}
+    VALUES = ''
+    if parameter_names != ['*']:
+        values = ' '.join([f'<{p}>' if p.startswith('http') else
+                           f'variablename:{p}'
+                           for p in parameter_names])
+        VALUES = f'VALUES ?odmvariable {{ {values} }}'
 
-    VALUES = ' '.join([f'<{p}>' if p.startswith('http') else
-                       f'variablename:{p}'
-                       for p in parameter_names])
     query = f'''
         {PREFIXES}
         {SELECT}
         WHERE {{
-            VALUES ?odmvariable {{
-                {VALUES}
-            }}
-
+            {VALUES}
             ?collection skos:broader :c_1805cd26 .
             ?collection skos:prefLabel ?label .
             ?parameter skos:broader+ ?collection .

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -1,6 +1,7 @@
 
 import functools
 import logging
+import os
 from pathlib import Path
 from rdflib import Graph
 
@@ -8,7 +9,6 @@ from rdflib import Graph
 LOGGER = logging.getLogger(__name__)
 
 THISDIR = Path(__file__).parent.resolve()
-GRAPH = THISDIR / 'ontology.ttl'
 
 SELECT = 'SELECT ?collection_id ?parameter_name ?odmvariable ?odmvarname'
 
@@ -28,6 +28,8 @@ BIND(REPLACE(STR(?parameter), "^.*/", "") AS ?parameter_name)
 
 @functools.cache
 def get_graph() -> Graph:
+    GRAPH = os.getenv('PYGEOAPI_ONTOLOGY_GRAPH',
+                      THISDIR / 'ontology.ttl')
     return Graph().parse(GRAPH)
 
 
@@ -67,7 +69,10 @@ def get_mapping(parameter_names: list) -> dict:
                     'title': str(c.odmvarname)
                 }
             }
+        else:
+            resp[cid][pname] = {
+                'key': str(c.odmvariable),
+                'title': str(c.odmvarname)
+            }
 
     return resp
-
-get_graph()

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -83,6 +83,7 @@ def get_mapping(parameter_names: list) -> dict:
             ?parameter skos:exactMatch ?odmvariable .
             ?odmvariable skos:prefLabel ?odmvarname .
 
+            FILTER(STRSTARTS(STR(?odmvariable), STR(variablename:)))
             {BINDS}
         }}
     '''

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -22,7 +22,7 @@ PREFIX dct: <http://purl.org/dc/terms/>
 
 BINDS = '''
 BIND(CONCAT(LCASE(STR(?label)), "-edr") AS ?collection_id)
-BIND(REPLACE(STR(?parameter), "^.*/", "") AS ?parameter_name)
+BIND(REPLACE(STR(?parameter), "^.*[#/]", "") AS ?parameter_name)
 '''
 
 

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -1,0 +1,80 @@
+
+import functools
+import logging
+from pathlib import Path
+from rdflib import Graph
+
+
+LOGGER = logging.getLogger(__name__)
+
+THISDIR = Path(__file__).parent.resolve()
+GRAPH = THISDIR / 'ontology.ttl'
+
+SELECT = 'SELECT ?collection_id ?parameter_name ?odmvariable ?odmvarname'
+
+PREFIXES = '''
+PREFIX : <http://lincolninst.edu/cgs/vocabularies/usbr#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX variablename: <http://vocabulary.odm2.org/variablename/>
+PREFIX dct: <http://purl.org/dc/terms/>
+'''
+
+BINDS = '''
+BIND(CONCAT(LCASE(STR(?label)), "-edr") AS ?collection_id)
+BIND(REPLACE(STR(?parameter), "^.*/", "") AS ?parameter_name)
+'''
+
+
+@functools.cache
+def get_graph() -> Graph:
+
+    g = Graph()
+    g.parse(GRAPH)
+    return g
+
+
+def get_mapping(parameter_names: list) -> dict:
+    resp = {}
+
+    VALUES = ' '.join([f'<{p}>' if p.startswith('http') else
+                       f'variablename:{p}'
+                       for p in parameter_names])
+    query = f'''
+        {PREFIXES}
+        {SELECT}
+        WHERE {{
+            VALUES ?odmvariable {{
+                {VALUES}
+            }}
+
+            ?collection skos:broader :c_1805cd26 .
+            ?collection skos:prefLabel ?label .
+            ?parameter skos:broader+ ?collection .
+            ?parameter rdf:type skos:Concept .
+            ?parameter skos:inScheme ?scheme .
+            ?parameter skos:exactMatch ?odmvariable .
+            ?odmvariable skos:prefLabel ?odmvarname .
+
+            {BINDS}
+        }}
+    '''
+    qres = get_graph().query(query)
+    for row in qres:
+        cid = str(row.collection_id)
+        pname = str(row.parameter_name)
+        if cid not in resp:
+            resp[cid] = {
+                pname: {
+                    'id': str(row.odmvariable),
+                    'name': str(row.odmvarname)
+                }
+            }
+
+    return resp
+
+
+if __name__ == '__main__':
+    get_mapping(['reservoirStorage'])
+else:
+    get_graph()

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -41,7 +41,7 @@ EDR_QUERY_TYPES = ['position', 'radius', 'area', 'cube',
 class BaseEDRProvider(BaseProvider):
     """Base EDR Provider"""
 
-    query_types = []
+    query_types = set()
 
     def __init__(self, provider_def):
         """
@@ -64,7 +64,7 @@ class BaseEDRProvider(BaseProvider):
                 LOGGER.error(msg)
                 raise ProviderInvalidDataError(msg)
 
-            cls.query_types.append(fn.__name__)
+            cls.query_types.add(fn.__name__)
             return fn
         return inner
 
@@ -84,7 +84,7 @@ class BaseEDRProvider(BaseProvider):
         :returns: `list` of EDR query types
         """
 
-        return self.query_types
+        return list(self.query_types)
 
     def query(self, **kwargs):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ python-dateutil
 pytz
 PyYAML
 rasterio
+rdflib
 requests
 shapely
 SQLAlchemy

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -169,6 +169,7 @@ def test_multiple_mappings():
 
     assert len(result['usace-edr']) == 1
 
+
 def test_all_mappings():
     result = get_mapping(['*'])
 

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -168,3 +168,31 @@ def test_multiple_mappings():
     assert mapping['title'] == 'Reservoir storage'
 
     assert len(result['usace-edr']) == 1
+
+def test_all_mappings():
+    result = get_mapping(['*'])
+
+    assert 'rise-edr' in result
+    assert '47' in result['rise-edr']
+
+    mapping = result['rise-edr']['47']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    mapping = result['rise-edr']['20']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/streamflow'
+    assert mapping['title'] == 'Streamflow'
+
+    assert len(result['rise-edr']) == 261
+
+    assert 'usace-edr' in result
+    assert 'Conservation+Storage' in result['usace-edr']
+
+    mapping = result['usace-edr']['Conservation+Storage']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['usace-edr']) == 1

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,3 +1,31 @@
+# =================================================================
+#
+# Authors: Ben Webb <bwebb@lincolninst.edu>
+#
+# Copyright (c) 2025 Ben Webb
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
 
 import pytest
 from rdflib import Graph, Namespace, URIRef, Literal

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,115 @@
+
+import pytest
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF, SKOS
+from pygeoapi.ontology import get_mapping, get_graph
+
+# Namespaces
+USBR = Namespace("http://lincolninst.edu/cgs/vocabularies/usbr#")
+VAR = Namespace("http://vocabulary.odm2.org/variablename/")
+
+
+@pytest.fixture
+def ontology_file(tmp_path):
+    ttl_path = tmp_path / "ontology.ttl"
+
+    g = Graph()
+    g.bind("skos", SKOS)
+    g.bind("", USBR)
+    g.bind("variablename", VAR)
+
+    # Collection hierarchy
+    parent = USBR["c_1805cd26"]
+    collection = USBR["rise"]
+    param = USBR["47"]
+    odmvar = VAR["reservoirStorage"]
+
+    g.add((parent, RDF.type, SKOS.Concept))
+    g.add((collection, SKOS.broader, parent))
+    g.add((collection, SKOS.prefLabel, Literal("Rise")))
+
+    g.add((param, SKOS.broader, collection))
+    g.add((param, RDF.type, SKOS.Concept))
+    g.add((param, SKOS.inScheme, URIRef("http://example.org/scheme")))
+    g.add((param, SKOS.exactMatch, odmvar))
+
+    g.add((odmvar, SKOS.prefLabel, Literal("Reservoir storage")))
+
+    g.serialize(destination=ttl_path, format="turtle")
+    return ttl_path
+
+
+def test_env_mapping(monkeypatch, ontology_file):
+    monkeypatch.setenv("PYGEOAPI_ONTOLOGY_GRAPH", str(ontology_file))
+    get_graph.cache_clear()
+    result = get_mapping(['reservoirStorage'])
+
+    assert 'rise-edr' in result
+    assert '47' in result['rise-edr']
+
+    mapping = result['rise-edr']['47']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['rise-edr']) == 1
+
+    assert 'usace-edr' not in result
+
+
+def test_get_mapping():
+    get_graph.cache_clear()
+    result = get_mapping(['reservoirStorage'])
+
+    assert 'rise-edr' in result
+    assert '47' in result['rise-edr']
+
+    mapping = result['rise-edr']['47']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['rise-edr']) == 3
+
+    assert 'usace-edr' in result
+    assert 'Conservation+Storage' in result['usace-edr']
+
+    mapping = result['usace-edr']['Conservation+Storage']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['usace-edr']) == 1
+
+
+def test_url_mapping():
+    get_graph.cache_clear()
+    result = get_mapping(
+        ['http://vocabulary.odm2.org/variablename/reservoirStorage']
+    )
+
+    assert 'rise-edr' in result
+    assert '47' in result['rise-edr']
+
+    mapping = result['rise-edr']['47']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['rise-edr']) == 3
+
+    assert 'usace-edr' in result
+    assert 'Conservation+Storage' in result['usace-edr']
+
+    mapping = result['usace-edr']['Conservation+Storage']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['usace-edr']) == 1
+
+
+def test_empty_mapping():
+    get_graph.cache_clear()
+    result = get_mapping(['notReservoirStorage'])
+    assert result == {}

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -83,7 +83,6 @@ def test_get_mapping():
 
 
 def test_url_mapping():
-    get_graph.cache_clear()
     result = get_mapping(
         ['http://vocabulary.odm2.org/variablename/reservoirStorage']
     )
@@ -110,6 +109,34 @@ def test_url_mapping():
 
 
 def test_empty_mapping():
-    get_graph.cache_clear()
     result = get_mapping(['notReservoirStorage'])
     assert result == {}
+
+
+def test_multiple_mappings():
+    result = get_mapping(['reservoirStorage', 'streamflow'])
+
+    assert 'rise-edr' in result
+    assert '47' in result['rise-edr']
+
+    mapping = result['rise-edr']['47']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    mapping = result['rise-edr']['20']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/streamflow'
+    assert mapping['title'] == 'Streamflow'
+
+    assert len(result['rise-edr']) == 11
+
+    assert 'usace-edr' in result
+    assert 'Conservation+Storage' in result['usace-edr']
+
+    mapping = result['usace-edr']['Conservation+Storage']
+    assert mapping['key'] == \
+        'http://vocabulary.odm2.org/variablename/reservoirStorage'
+    assert mapping['title'] == 'Reservoir storage'
+
+    assert len(result['usace-edr']) == 1


### PR DESCRIPTION
# Overview
Support basic ontology resolution by extending `parameter-name` query argument from EDR to the landing page and collections view. In the collections view it will act as a filter to only show collections / parameters that match the requested ODM2 vocabulary terms. 
