### PR TITLE
Add formatter mimetype to content type header if present

### DIFF
--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -520,7 +520,8 @@ def get_collection_edr_query(api: API, request: APIRequest,
             filename = f'{dataset}.{formatter.extension}'
             cd = f'attachment; filename="{filename}"'
             headers['Content-Disposition'] = cd
-
+            if hasattr(formatter, 'mimetype'):
+                headers['Content-Type'] = formatter.mimetype
     else:
         headers['Content-Type'] = 'application/vnd.cov+json'
         content = to_json(data, api.pretty_print)

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -520,8 +520,7 @@ def get_collection_edr_query(api: API, request: APIRequest,
             filename = f'{dataset}.{formatter.extension}'
             cd = f'attachment; filename="{filename}"'
             headers['Content-Disposition'] = cd
-            if hasattr(formatter, 'mimetype'):
-                headers['Content-Type'] = formatter.mimetype
+            headers['Content-Type'] = formatter.mimetype
     else:
         headers['Content-Type'] = 'application/vnd.cov+json'
         content = to_json(data, api.pretty_print)


### PR DESCRIPTION
Add formatter mimetype to content type header if present

fixes issue where the browser tries to parse a csv as json due to the mimetype not being set