### PR TITLE
Add back name key

### DIFF
--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -414,8 +414,9 @@ def gen_collection(api, request, dataset: str,
                 p_description = value.get('description')
                 data['parameter_names'][key] = {
                     'id': key,
-                    # this is a key that was previously present; it is not part of the 
-                    # spec but doesn't deviate either; used for compatibility; eventually
+                    # this is a key that was previously present;
+                    # it is not part of the spec but doesn't deviate
+                    #  either; used for compatibility; eventually
                     # it can be removed
                     'name': p_label,
                     'type': 'Parameter',

--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -414,6 +414,10 @@ def gen_collection(api, request, dataset: str,
                 p_description = value.get('description')
                 data['parameter_names'][key] = {
                     'id': key,
+                    # this is a key that was previously present; it is not part of the 
+                    # spec but doesn't deviate either; used for compatibility; eventually
+                    # it can be removed
+                    'name': p_label,
                     'type': 'Parameter',
                     'observedProperty': {
                         'label': {

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -215,6 +215,9 @@ def apply_mapping(
                 'type': 'ParameterGroup',
                 'id': id,
                 'label': param,
+                # this name key is a holdout for compatibility reasons
+                # it can eventually be removed once the frontend no longer depends on it
+                'name': param,
                 'observedProperty': {
                     'id': param,
                     'label': {'en': param}

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -216,7 +216,8 @@ def apply_mapping(
                 'id': id,
                 'label': param,
                 # this name key is a holdout for compatibility reasons
-                # it can eventually be removed once the frontend no longer depends on it
+                # it can eventually be removed once the frontend no longer
+                # depends on it
                 'name': param,
                 'observedProperty': {
                     'id': param,


### PR DESCRIPTION
john needs this name key. The latest pygeoapi version seems to have removed it. eventually we want to migrate the frontend to just use name but this is sufficient for the time being