### PR TITLE
Allow for collection to override `skip_caching_args`

### DIFF
--- a/pygeoapi/flask_app/__init__.py
+++ b/pygeoapi/flask_app/__init__.py
@@ -406,6 +406,7 @@ def get_collection_tiles_data(collection_id: str | None = None,
 
 @BLUEPRINT.route('/collections/<collection_id>/map')
 @BLUEPRINT.route('/collections/<collection_id>/styles/<style_id>/map')
+@FLASK_CACHE.cached_view(skip_caching_args=['bbox'])
 def collection_map(collection_id: str, style_id: str | None = None):
     """
     OGC API - Maps map render endpoint
@@ -504,6 +505,7 @@ def get_job_result(job_id: str | None = None):
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/locations')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>')
 @BLUEPRINT.route('/collections/<path:collection_id>/instances')
+@FLASK_CACHE.cached_view(skip_caching_args=['bbox', 'coords'])
 def get_collection_edr_query(collection_id: str,
                              instance_id: str | None = None,
                              location_id: str | None = None):

--- a/pygeoapi/flask_app/cache.py
+++ b/pygeoapi/flask_app/cache.py
@@ -47,7 +47,7 @@ DEFAULT_TTL = os.environ.get('PYGEOAPI_DEFAULT_CACHE_TTL_SECONDS', 3600)
 
 class FlaskCache(Cache):
     """Wrapper around to add a decorator for caching OGC API Flask views"""
-    def cache_view(
+    def cached_view(
         self,
         skip_caching_args: list[str] | None = None,
         always_cache: bool = False
@@ -56,7 +56,7 @@ class FlaskCache(Cache):
         Decorator to cache flask views
 
         :param skip_caching_args: `list` of arguments that when present in
-            the request will skip the cache
+            the request will bypass the cache
         :param always_cache: if True, the view will try to cache without
             the pygeoapi configuration for the particular resource;
             This is useful for caching endpoints like `/collections`
@@ -66,6 +66,15 @@ class FlaskCache(Cache):
         :returns: decorated flask view function
         """
 
+        def get_cache_config():
+            # cache configuration is stored at collection level
+            # to allow for caching strategies specific to a collection
+            view_args = request.view_args or {}
+            collection_id = view_args.get('collection_id')
+            resources = CONFIG.get('resources', {})
+            collection_cfg = resources.get(collection_id, {})
+            return collection_cfg.get('flask_cache', {})
+
         def decorator(f):
             # if the view has not been configured to be cached, skip it
             def skip_cache():
@@ -74,17 +83,25 @@ class FlaskCache(Cache):
                     # will still defer to Cache-Control headers
                     return False
 
+                cache_config = get_cache_config()
+
                 if skip_caching_args:
+                    # allow for a collection to cache on arguments
+                    # that have been configured to bypass the cache
+                    # enabling runtime control over cahing without
+                    # needing to change pygeoapi source code
+                    allowed_args = cache_config.get('allowed_cache_keys', [])
+                    bypass_cache_args = [
+                        arg for arg in skip_caching_args
+                        if arg not in allowed_args
+                    ]
+
                     query_args = request.values
-                    for arg in skip_caching_args:
+                    for arg in bypass_cache_args:
                         if arg in query_args:
                             return True
 
-                view_args = request.view_args or {}
-                collection_id = view_args.get('collection_id')
-                resources = CONFIG.get('resources', {})
-                collection_cfg = resources.get(collection_id, {})
-                return not collection_cfg.get('flask_cache')
+                return not cache_config
 
             # the full request path with parameters as well as the
             # method is used for the cache key however we do not
@@ -94,20 +111,15 @@ class FlaskCache(Cache):
                 return f'view/{request.method}/{request.full_path}'
 
             def get_ttl():
-                view_args = request.view_args or {}
-                collection_id = view_args.get('collection_id')
-                resources = CONFIG.get('resources', {})
-                collection_cfg = resources.get(collection_id, {})
-                cache_config = collection_cfg.get('flask_cache', {})
+                cache_config = get_cache_config()
 
-                if 'ttl_seconds' in cache_config:
-                    return cache_config['ttl_seconds']
+                if 'ttl_seconds' not in cache_config:
+                    LOGGER.warning(
+                        f'ttl_seconds not configured using default of'
+                        f'{DEFAULT_TTL} seconds'
+                    )
 
-                LOGGER.warning(
-                    f'ttl_seconds not configured for {collection_id=}, '
-                    f'defaulting to {DEFAULT_TTL} seconds'
-                )
-                return DEFAULT_TTL
+                return cache_config.get('ttl_seconds', DEFAULT_TTL)
 
             @wraps(f)
             def wrapped(*args, **kwargs):


### PR DESCRIPTION
# Overview
- Allow for the `flask_cache` of a configured resource to _not_ bypass cache when specific args are present. This will allow us to potentially cache EDR and Map queries without needing to modify pygeoapi source code
- Add cache view for map and edr flask routes
- 
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
