### PR TITLE
Few type cleanups for ontology

### DIFF
--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -225,9 +225,6 @@ def apply_mapping(
     # `/collections` and `/collections/{collection_id}` queries
     if parameter not in onto_mapping[dataset]:
         LOGGER.warning(f'No mapping found for {parameter} in {dataset}')
-        assert isinstance(parameters, dict), \
-            f'parameters must be a dict to pop {parameter}; {parameters}'
-
         parameters.pop(parameter)
         return
 

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -32,7 +32,7 @@ import logging
 import os
 from pathlib import Path
 from rdflib import Graph
-from typing import TypedDict
+from typing import Any, TypedDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -164,7 +164,9 @@ def _get_mapping(
         }}
     """
     try:
-        response = get_graph().query(query)
+        # rdflib does not type properly, thus
+        # it must be simply declared as Any
+        response: Any = get_graph().query(query)
     except Exception:
         msg = 'Unable to find parameter in ontology mapping'
         LOGGER.warning(msg, exc_info=True)

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -79,10 +79,12 @@ def get_graph() -> Graph:
     GRAPH = os.getenv('PYGEOAPI_ONTOLOGY_GRAPH', THISDIR / 'ontology_min.ttl')
     if Path(GRAPH).exists():
         return Graph().parse(GRAPH)
+    else:
+        raise FileNotFoundError(f"Ontology graph not found at {GRAPH}")
 
 
 def get_mapping(
-    parameter_names: str | list = None,
+    parameter_names: str | list | None = None,
 ) -> dict[str, dict[str, KeyTitleDict]]:
     """
     Query Ontology graph for matching EDR collection and parameters
@@ -223,6 +225,9 @@ def apply_mapping(
     # `/collections` and `/collections/{collection_id}` queries
     if parameter not in onto_mapping[dataset]:
         LOGGER.warning(f'No mapping found for {parameter} in {dataset}')
+        assert isinstance(parameters, dict), \
+            f'parameters must be a dict to pop {parameter}; {parameters}'
+
         parameters.pop(parameter)
         return
 


### PR DESCRIPTION
there are still some other things but for the time being this cleans up some low hanging fruit. since the ontology has to operate upon many different structures of json, it might make sense to add more type info and/or explicitly split the cases for that geojson special case in some way. I don't want to break anything so I avoiding changing anything that wasn't immediately clear to me