### PR TITLE
prevent log spam for unmapped parameter

### DIFF
--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -226,7 +226,7 @@ def apply_mapping(
     # if not, then filter out this parameter. Should only apply to
     # `/collections` and `/collections/{collection_id}` queries
     if parameter not in onto_mapping[dataset]:
-        LOGGER.warning(f'No mapping found for {parameter} in {dataset}')
+        LOGGER.debug(f'No mapping found for {parameter} in {dataset}')
         parameters.pop(parameter)
         return
 


### PR DESCRIPTION
If a parameter isn't mapped in the ontology it can cause lots of log spam which makes it harder to determine other errors. Made a quick change to make it log level debug. Since having an unmapped parameter may not be an issue.

```
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1749 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1748 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1747 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1746 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1745 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1744 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1743 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1742 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1741 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1740 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1739 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1738 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1737 in rise-edr
[2026-04-20T08:44:48Z] {/Users/cloftus/github/ArizonaWaterObservatory/.venv/lib/python3.12/site-packages/pygeoapi/ontology/__init__.py:229} WARNING - No mapping found for 1736 in rise-edr
```