### PR TITLE
Fix CORS on headers

### DIFF
--- a/pygeoapi/flask_app/__init__.py
+++ b/pygeoapi/flask_app/__init__.py
@@ -88,7 +88,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, CORS_EXPOSE_HEADERS=['*'])
+        CORS(APP, expose_headers=['*'], allow_headers=['*'], methods=['*'])
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 

--- a/pygeoapi/flask_app/__init__.py
+++ b/pygeoapi/flask_app/__init__.py
@@ -88,7 +88,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, expose_headers='*')
+        CORS(APP, CORS_EXPOSE_HEADERS="*")
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 

--- a/pygeoapi/flask_app/__init__.py
+++ b/pygeoapi/flask_app/__init__.py
@@ -88,7 +88,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, expose_headers=['*'], allow_headers=['*'], methods=['*'])
+        CORS(APP, expose_headers='*')
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 


### PR DESCRIPTION
John needs
```
Access-Control-Expose-Headers: *
```
else he can't get the location response from the header in the browser since the headers are being excluded. It seems like flask cors doesn't allow this arg to be a list, but it must be a a `*` directly