### PR TITLE
Support parameters in the ontology layer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
       - '**.md'
       - 'docs/**'
   pull_request:
+    branches:
+      - master
     paths-ignore:
       - '!**.md'
       - 'docs/**'

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,6 @@ RUN python3 -m venv --system-site-packages /venv \
     && /venv/bin/python3 -m pip install --no-cache-dir -r requirements-docker.txt \
     && /venv/bin/python3 -m pip install --no-cache-dir -r requirements-admin.txt \
     && /venv/bin/python3 -m pip install --no-cache-dir "gunicorn<24" \
-    && /venv/bin/python3 -m pip install --no-cache-dir https://github.com/cgs-earth/pygeoapi-plugins/archive/refs/heads/master.zip \
     && /venv/bin/python3 -m pip install --no-cache-dir -e .
 
 # Set default config and entrypoint for Docker Image

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md LICENSE.md requirements.txt
-recursive-include pygeoapi *.html *.json *.jsonld *.yml *.ttl
+recursive-include pygeoapi *.html *.json *.jsonld *.yml
 recursive-include pygeoapi/static *

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -147,14 +147,9 @@ case ${entry_cmd} in
             find . -type f -name "*.py" | xargs chmod 0444
         fi
 
-		# Include Jinja templates
-		EXTRA_FILES=$(find /pygeoapi/pygeoapi/templates -type f -exec echo --reload-extra-file {} \; | xargs)
-
-		# Start with hot reload options
-		start_gunicorn --reload \
-			--reload-extra-file ${PYGEOAPI_CONFIG} \
-			${EXTRA_FILES}
-		;;
+        # Start with hot reload options
+        start_gunicorn --reload --reload-extra-file ${PYGEOAPI_CONFIG}
+        ;;
 
     *)
         error "unknown command arg: must be run (default), run-with-hot-reload, or test"

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1053,11 +1053,6 @@ def describe_collections(api: API, request: APIRequest,
     if dataset is not None:
         fcm = fcm['collections'][0]
 
-    if fcm.get('collections') == []:
-        msg = 'No matching sources found'
-        return api.get_exception(
-            HTTPStatus.NOT_FOUND, headers, request.format, 'NotFound', msg)
-
     if parameter_groups != {}:
         fcm['parameterGroups'] = [*parameter_groups.values()]
 

--- a/pygeoapi/flask_app/__init__.py
+++ b/pygeoapi/flask_app/__init__.py
@@ -88,7 +88,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, expose_headers="*")
+        CORS(APP, expose_headers='*')
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -41,7 +41,7 @@ THISDIR = Path(__file__).parent.resolve()
 
 SELECT = (
     'SELECT DISTINCT ?collection_id ?parameter_id ?parameter_name '
-    '?parameter_def ?concept_name ?concept_group'
+    '?parameter_def ?parameter_unit ?concept_name ?concept_group'
 )
 
 SKOS_ANYMATCH = (
@@ -59,6 +59,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX variablename: <http://vocabulary.odm2.org/variablename/>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX qudt: <http://qudt.org/schema/qudt/>
 """
 
 
@@ -159,6 +160,9 @@ def _get_mapping(
         OPTIONAL {{
             ?concept_group skos:definition ?parameter_def .
         }}
+        OPTIONAL {{
+            ?concept_group qudt:hasUnit ?parameter_unit .
+        }}
 
         ?match {SKOS_ANYMATCH} ?concept_group ;
             skos:broader/skos:hiddenLabel ?collection_id ;
@@ -180,6 +184,7 @@ def _get_mapping(
         parameter_id = row.parameter_id.toPython().replace('+', ' ')
         parameter_name = str(row.parameter_name or '')
         parameter_def = str(row.parameter_def or '')
+        parameter_unit = str(row.parameter_unit or '')
         concept_name = row.concept_name.toPython()
         concept_group = row.concept_group.toPython()
 
@@ -190,7 +195,8 @@ def _get_mapping(
             .update({
                 concept_name: concept_group,
                 'parameter_name': parameter_name,
-                'parameter_def': parameter_def
+                'parameter_def': parameter_def,
+                'parameter_unit': parameter_unit
             })
         )
 
@@ -241,7 +247,7 @@ def apply_mapping(
     # Get ontology mapping for this dataset and parameter
     param_mapping = deepcopy(onto_mapping[dataset][parameter])
 
-    # Fetch the parameter name and definition from the mapping, if available
+    # Fetch the parameter name, unit and definition from the mapping,
     # and apply them to the parameter's name and observedProperty description.
     # This allows us to provide more user-friendly labels and descriptions for
     # parameters based on the Vocbench concept mapping
@@ -253,6 +259,15 @@ def apply_mapping(
     param_def = param_mapping.pop('parameter_def', None)
     if param_def:
         obs_prop['description'] = {'en': param_def}
+
+    param_unit = param_mapping.pop('parameter_unit', None)
+    if param_unit:
+
+        prefix, term = param_unit.rsplit('/', 1)
+        parameters[parameter]['unit']['symbol'] = {
+            'value': term,
+            'type': prefix
+        }
 
     # Remaining items are groups that the parameter is mapped to
     # which mean we need to add the parameter to the corresponding group

--- a/pygeoapi/ontology/ontology_min.ttl
+++ b/pygeoapi/ontology/ontology_min.ttl
@@ -33817,7 +33817,7 @@ skos:semanticRelation a rdf:Property,
 <https://api.wwdh.internetofwater.app/collections/usgs-prism> a skos:Collection,
         skos:Concept ;
     skos:broader <https://api.wwdh.internetofwater.app/collections> ;
-    skos:hiddenLabel "usgs-prism"@en-us ;
+    skos:hiddenLabel "usgs-prism2"@en-us ;
     skos:inScheme <https://api.wwdh.internetofwater.app> ;
     skos:member "https://api.wwdh.internetofwater.app/collections/usgs-prism/cube"^^xsd:anyURI,
         "https://api.wwdh.internetofwater.app/collections/usgs-prism/position"^^xsd:anyURI ;

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -127,7 +127,9 @@
                       <td>{{sub}}
                       {% set parameter = data.parameter_names[sub] %}
                       <td>{{ parameter['observedProperty']['label'].values()|first }}{% if parameter['observedProperty']['description'] %}<br/><i>{{ parameter['observedProperty']['description'].values()|first }}</i>{% endif %}</td>
-                      <td>{{ parameter['unit']['symbol']['value'] }}</td>
+                      <td>
+                        <a title="{{ parameter['unit']['label'].values()|first }}" href="{{ parameter.unit.symbol.type }}{{ parameter.unit.symbol.value }}">{{ parameter['unit']['symbol']['value'] }}</a>
+                      </td>
                     </tr>
                   {% endfor %}
                 </table>

--- a/pygeoapi/templates/collections/index.html
+++ b/pygeoapi/templates/collections/index.html
@@ -79,9 +79,9 @@
                         <summary><strong>{{ config.resources[k].title | striptags }}</strong> ({{ v|length }} matches)</summary>
                         <table style="background: #FFF" class="table table-condensed mb-0">
                           <tr>
-                            <th>id</th>
+                            <th style="width: 120px;">id</th>
                             <th>name</th>
-                            <th>units</th>
+                            <th style="width: 120px;">units</th>
                           </tr>
                           {% if v[0] | int != 0 %}
                             {% set v = v | map('int') | sort | map('string') %}
@@ -91,7 +91,9 @@
                             <td>{{ sub }}</td>
                             {% set parameter = parameter_names[sub] %}
                             <td>{{ parameter['observedProperty']['label'].values()|first }}{% if parameter['observedProperty']['description'] %}<br/><i>{{ parameter['observedProperty']['description'].values()|first }}</i>{% endif %}</td>
-                            <td>{{ parameter['unit']['symbol']['value'] }}</td>
+                            <td>
+                              <a title="{{ parameter['unit']['label'].values()|first }}" href="{{ parameter.unit.symbol.type }}{{ parameter.unit.symbol.value }}">{{ parameter['unit']['symbol']['value'] }}</a>
+                            </td>
                           </tr>
                           {% endfor %}
                         </table>

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -306,7 +306,7 @@ def file_modified_iso8601(filepath: Path) -> str:
     """
 
     return datetime.fromtimestamp(
-        os.path.getmtime(filepath)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        os.path.getctime(filepath)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
 def human_size(nbytes: int) -> str:

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,6 +1,5 @@
 elasticsearch-dsl<8
 geoalchemy2
-pygeoapi-plugins
 pygeofilter[backend-sqlalchemy]
 pygeoif
 pygeometa

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask
 Flask-Caching
 jinja2
 jsonschema
-pydantic>2.0
+pydantic
 pygeoapi-plugins
 pygeofilter
 pygeoif

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -640,7 +640,7 @@ def test_describe_collections(config, api_):
     rsp_headers, code, response = describe_collections(api_, req)
     collections = json.loads(response)
 
-    assert len(collections) == 3
+    assert len(collections) == 2
     assert len(collections['collections']) == 10
     assert len(collections['links']) == 3
 

--- a/tests/provider/test_csw_provider.py
+++ b/tests/provider/test_csw_provider.py
@@ -1,0 +1,286 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Francesco Bartoli <xbartolone@gmail.com>
+#
+# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2025 Francesco Bartoli
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from unittest import mock
+import pytest
+
+from pygeoapi.provider.base import ProviderItemNotFoundError
+from pygeoapi.provider.csw_facade import CSWFacadeProvider
+
+CSW_PROVIDER = 'pygeoapi.provider.csw_facade.CatalogueServiceWeb'
+
+
+@pytest.fixture()
+def config():
+    return {
+        'name': 'CSWFacade',
+        'type': 'record',
+        'data': 'https://demo.pycsw.org/cite/csw',
+        'id_field': 'identifier',
+        'time_field': 'date'
+    }
+
+
+@pytest.fixture()
+def mock_csw_record():
+    """Mock owslib CSW record"""
+    record = mock.MagicMock()
+    record.identifier = 'urn:uuid:19887a8a-f6b0-4a63-ae56-7fba0e17801f'
+    record.title = 'Lorem ipsum'
+    record.abstract = 'Lorem ipsum dolor sit amet'
+    record.type = 'http://purl.org/dc/dcmitype/Image'
+    record.subjects = ['Tourism--Greece']
+    record.date = '2006-03-26'
+    record.created = None
+    record.modified = None
+    record.rights = None
+    record.language = None
+    record.bbox = None  # No geometry for first record
+    record.references = []
+    record.uris = []
+    return record
+
+
+@pytest.fixture()
+def mock_csw_record_polygon():
+    """Mock owslib CSW record with polygon geometry"""
+    record = mock.MagicMock()
+    record.identifier = 'urn:uuid:1ef30a8b-876d-4828-9246-c37ab4510bbd'
+    record.title = 'Maecenas enim'
+    record.abstract = 'Maecenas enim'
+    record.type = 'http://purl.org/dc/dcmitype/Text'
+    record.subjects = []
+    record.date = '2006-05-12'
+    record.created = None
+    record.modified = None
+    record.rights = None
+    record.language = None
+    record.bbox = mock.MagicMock()
+    record.bbox.minx = '13.754'
+    record.bbox.miny = '60.042'
+    record.bbox.maxx = '15.334'
+    record.bbox.maxy = '61.645'
+    record.references = []
+    record.uris = []
+    return record
+
+
+@pytest.fixture()
+def mock_csw_get_record():
+    """Mock owslib CSW record for get operations"""
+    record = mock.MagicMock()
+    record.identifier = 'urn:uuid:a06af396-3105-442d-8b40-22b57a90d2f2'
+    record.title = 'Lorem ipsum dolor sit amet'
+    record.abstract = 'Lorem ipsum dolor sit amet'
+    record.type = 'http://purl.org/dc/dcmitype/Image'
+    record.subjects = []
+    record.date = None
+    record.created = None
+    record.modified = None
+    record.rights = None
+    record.language = None
+    record.bbox = None
+    record.references = []
+    record.uris = []
+    return record
+
+
+@pytest.fixture()
+def mock_csw(mock_csw_record, mock_csw_record_polygon, mock_csw_get_record):
+    """Mock CSW service"""
+    with mock.patch(CSW_PROVIDER) as mock_csw_class:
+        csw_instance = mock.MagicMock()
+        mock_csw_class.return_value = csw_instance
+
+        def mock_getrecords2(*args, **kwargs):
+            # Simulate different responses based on parameters
+            limit = kwargs.get('maxrecords', 10)
+            offset = kwargs.get('startposition', 0)
+            constraints = kwargs.get('constraints', [])
+
+            # All available records
+            all_records = [
+                (
+                    'urn:uuid:19887a8a-f6b0-4a63-ae56-7fba0e17801f',
+                    mock_csw_record
+                ),
+                (
+                    'urn:uuid:1ef30a8b-876d-4828-9246-c37ab4510bbd',
+                    mock_csw_record_polygon
+                )
+            ]
+
+            # Simulate filtering based on query constraints
+            filtered_records = all_records[:]
+
+            # Simulate different total counts based on constraints
+            total_matches = 12  # Default total
+            if constraints:
+                # If there are constraints
+                # simulate fewer matches
+                constraint_str = str(constraints)
+                if 'lorem' in constraint_str.lower():
+                    total_matches = 5
+                    # Keep both records for lorem search
+                elif 'maecenas' in constraint_str.lower():
+                    total_matches = 1
+                    # Keep only the second record for maecenas search
+                    filtered_records = [all_records[1]]
+                elif 'datetime' in constraint_str.lower():
+                    total_matches = 1 if '2006-05-12' in constraint_str else 3
+                    # Keep appropriate records based on date
+                    if '2006-05-12' in constraint_str:
+                        # Second record has matching date
+                        filtered_records = [all_records[1]]
+
+            # Apply offset and limit to filtered records
+            paginated_records = filtered_records[offset:offset+limit]
+
+            # Convert to dictionary format expected by CSW
+            csw_instance.records = {
+                record_id: record for record_id, record in paginated_records
+            }
+            csw_instance.results = {
+                'matches': total_matches,
+                'returned': len(paginated_records)
+            }
+
+        def mock_getrecordbyid(identifiers, **kwargs):
+            identifier = identifiers[0]
+            if identifier == 'urn:uuid:a06af396-3105-442d-8b40-22b57a90d2f2':
+                csw_instance.records = {identifier: mock_csw_get_record}
+            else:
+                csw_instance.records = {}
+
+        def mock_getdomain(property_name, **kwargs):
+            # Mock domain values for testing
+            domain_values = {
+                'type': [
+                    'http://purl.org/dc/dcmitype/Image',
+                    'http://purl.org/dc/dcmitype/Text',
+                    'http://purl.org/dc/dcmitype/Dataset',
+                    'http://purl.org/dc/dcmitype/Service'
+                ]
+            }
+            csw_instance.results = {
+                'values': domain_values.get(property_name, [])
+            }
+
+        csw_instance.getrecords2.side_effect = mock_getrecords2
+        csw_instance.getrecordbyid.side_effect = mock_getrecordbyid
+        csw_instance.getdomain.side_effect = mock_getdomain
+
+        yield csw_instance
+
+
+def test_domains(config, mock_csw):
+    p = CSWFacadeProvider(config)
+
+    domains, current = p.get_domains()
+
+    assert current
+
+    expected_properties = ['date', 'description', 'keywords', 'title', 'type']
+
+    assert sorted(domains.keys()) == expected_properties
+
+    assert len(domains['type']) == 4
+
+    domains, current = p.get_domains(['type'])
+
+    assert current
+
+    assert list(domains.keys()) == ['type']
+
+
+def test_query(config, mock_csw):
+    p = CSWFacadeProvider(config)
+
+    fields = p.get_fields()
+    assert len(fields) == 9
+
+    for key, value in fields.items():
+        assert value['type'] == 'string'
+
+    results = p.query()
+    assert len(results['features']) == 2  # Mock returns 2 records
+    assert results['numberMatched'] == 12
+    assert results['numberReturned'] == 2
+    assert results['features'][0]['id'] == 'urn:uuid:19887a8a-f6b0-4a63-ae56-7fba0e17801f'  # noqa
+    assert results['features'][0]['geometry'] is None
+    assert results['features'][0]['properties']['title'] == 'Lorem ipsum'
+    assert results['features'][0]['properties']['keywords'][0] == 'Tourism--Greece'  # noqa
+
+    assert results['features'][1]['geometry']['type'] == 'Polygon'
+    assert results['features'][1]['geometry']['coordinates'][0][0][0] == 13.754
+    assert results['features'][1]['geometry']['coordinates'][0][0][1] == 60.042
+
+    results = p.query(limit=1)
+    assert len(results['features']) == 1
+    assert results['features'][0]['id'] == 'urn:uuid:19887a8a-f6b0-4a63-ae56-7fba0e17801f'  # noqa
+
+    results = p.query(offset=1, limit=1)
+    assert len(results['features']) == 1
+    assert results['features'][0]['id'] == 'urn:uuid:1ef30a8b-876d-4828-9246-c37ab4510bbd' # noqa
+
+    results = p.query(resulttype='hits')
+    assert results['numberMatched'] == 12
+
+    results = p.query(bbox=[-10, 40, 0, 60])
+    assert len(results['features']) == 2
+
+    results = p.query(bbox=[-10, 40, 0, 60, 0, 0])
+    assert len(results['features']) == 2
+
+    results = p.query(properties=[('title', 'Maecenas enim')])
+    assert len(results['features']) == 2
+
+
+def test_get(config, mock_csw):
+    p = CSWFacadeProvider(config)
+
+    result = p.get('urn:uuid:a06af396-3105-442d-8b40-22b57a90d2f2')
+    assert result['id'] == 'urn:uuid:a06af396-3105-442d-8b40-22b57a90d2f2'
+    assert result['geometry'] is None
+    assert result['properties']['title'] == 'Lorem ipsum dolor sit amet'
+    assert result['properties']['type'] == 'http://purl.org/dc/dcmitype/Image'
+
+    xml_link = result['links'][0]
+    assert xml_link['rel'] == 'alternate'
+    assert xml_link['type'] == 'application/xml'
+    assert 'service=CSW' in xml_link['href']
+
+
+def test_get_not_existing_item_raise_exception(config, mock_csw):
+    """Testing query for a not existing object"""
+    p = CSWFacadeProvider(config)
+    with pytest.raises(ProviderItemNotFoundError):
+        p.get('404')


### PR DESCRIPTION
# Overview
Add support for parameter_unit as a QUDT artifact on the ontology layer

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
* Use JSON-LD link if found in HTML template

* Use found link

* Revert "Use found link"

This reverts commit 36e1841.