### PR TITLE
Apply filter only when queried

### DIFF
--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -402,6 +402,7 @@ def gen_collection(api, request, dataset: str,
         # TODO: translate
         LOGGER.debug('Adding EDR links')
         parameternames = request.params.get('parameter-name')
+        filter_parameters = parameternames is not None
         if isinstance(parameternames, str):
             parameternames = set(parameternames.split(','))
         onto_mapping = get_mapping(parameternames)
@@ -448,7 +449,8 @@ def gen_collection(api, request, dataset: str,
                     onto_mapping=onto_mapping,
                     parameter_groups=parameter_groups,
                     dataset=dataset,
-                    parameter=key
+                    parameter=key,
+                    filter_parameters=filter_parameters
                 )
 
         for qt in p.get_query_types():

--- a/pygeoapi/ontology/__init__.py
+++ b/pygeoapi/ontology/__init__.py
@@ -223,6 +223,7 @@ def apply_mapping(
     parameter_groups: dict,
     dataset: str,
     parameter: str,
+    filter_parameters: bool = False,
     single_dataset: bool = False,
 ):
     """
@@ -245,9 +246,9 @@ def apply_mapping(
         return
 
     # Check if parameter is in the ontology mapping for dataset (collection)
-    # if not, then filter out this parameter. Should only apply to
+    # if not, then filter out this parameter. Will only apply to
     # `/collections` and `/collections/{collection_id}` queries
-    if parameter not in onto_mapping[dataset]:
+    if parameter not in onto_mapping[dataset] and filter_parameters:
         LOGGER.debug(f'No mapping found for {parameter} in {dataset}')
         parameters.pop(parameter)
         return


### PR DESCRIPTION
# Overview
Apply parameter filter in ontology mapping only when all conditions have been met. The new condition is there is a ?parameter-name=X for the `/collections` and `/collections/{cid}` endpoints.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
